### PR TITLE
Add `woke` to tooling.md

### DIFF
--- a/ws-oss/tooling.md
+++ b/ws-oss/tooling.md
@@ -8,3 +8,4 @@ the Inclusive Naming Community workstream – please email ws-community@inclusiv
 
 | Name | Description | Link(s) | Demo date | Recording | 
 | --- | --- | --- | --- | --- | 
+| woke | Detect non-inclusive language in your source code. | https://github.com/get-woke/woke | TBD | TBD |

--- a/ws-oss/tooling.md
+++ b/ws-oss/tooling.md
@@ -1,6 +1,6 @@
 # Awesome Inclusive Language Tooling
 
-The following is a list of tools **not maintained by the Inclusive Naming Initiative** which can scan or lint for inclusive langugage concerns. 
+The following is a list of tools **not maintained by the Inclusive Naming Initiative** which can scan or lint for inclusive language concerns. 
 
 Tools included in this document must be demo'ed to the Inclusive Naming Initiative. PRs to this list should include a demonstration date discussed with
 the Inclusive Naming Community workstream – please email ws-community@inclusivenaming.org to contact them.

--- a/ws-oss/tooling.md
+++ b/ws-oss/tooling.md
@@ -8,4 +8,4 @@ the Inclusive Naming Community workstream – please email ws-community@inclusiv
 
 | Name | Description | Link(s) | Demo date | Recording | 
 | --- | --- | --- | --- | --- | 
-| woke | Detect non-inclusive language in your source code. | https://github.com/get-woke/woke | TBD | TBD |
+| woke | Detect non-inclusive language in your source code. | https://github.com/get-woke/woke | August 16, 2021 | TBD |


### PR DESCRIPTION
Hello Inclusive Naming Community! I emailed ws-community@inclusivenaming.org on July 22 and wanted to follow up via a PR here after reading the Slack message in https://inclusive-naming.slack.com/archives/C01KHU7SS68/p1626989815062000?thread_ts=1626989803.061900&cid=C01KHU7SS68. I would love to know how to get `woke` onto the demo schedule to have it included. Thanks in advance!

Original Email: 

> I am interested in including the tool I created and maintain, `woke` ([https://github.com/get-woke/woke](https://github.com/get-woke/woke)) on your tooling list. I believe I will need to demo the tool for the group, would you be able to let me know what steps I need to take to make this happen. Thank you in advance for your time and I'm very excited to see how this community has grown! Looking forward to being a part of it!