### PR TITLE
Lightweight web-of-trust for `ws-language` members

### DIFF
--- a/ws-language/CONTRIBUTING.md
+++ b/ws-language/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+This document describes a lightweight process for how to contribute to the Language Workstream (WS) of the [Inclusive Naming Initiative](https://inclusivenaming.org).
+Although this workstream has a chair that could be the gateway for contributions, we are choosing to have a more open web of trust amongst contributors.
+
+This process draws lightly on the culture of the ["do-ocracy"](https://www.theopensourceway.org/the_open_source_way-guidebook-2.0.html#_do_ocracy) but limited to just the Language WS.
+We are aware this is a more obscure way into the project, because it requires joining a meeting and/or the `#ws-language` when you [join our Slack](https://communityinviter.com/apps/inclusive-naming/invite), and then getting to know people.
+Because we are working on the most sensitive part of this project and there are only a handful of members (10 - 15), we are choosing this more direct relationship building before offering changes to the word lists.
+
+## How to become a contributor
+
+1. Join one of our bi-weekly meetings and/or the `#ws-language` channel after you [join our Slack](https://communityinviter.com/apps/inclusive-naming/invite).
+Introduce yourself and what brought you to the Inclusive Naming Initiative (INI).
+1. Join the [mailing list](https://groups.google.com/g/inclusivenaming) where you can introduce yourself to the wider project.
+1. Take a look at the [words and terms being discussed in our issue tracker on GitHub](https://github.com/inclusivenaming/org/issues?q=is%3Aissue+is%3Aopen+label%3ALanguage) to see where we are with specific terms.
+1. If you have a term you think we should discuss, file an issue describing it.
+An /issue/ is a record you create in GitHub as the central point for discussions around the term you are drawing attention to.
+1. You can request to join the GitHub project by [filing an issue in the `org` repository](https://github.com/inclusivenaming/org/issues/new); once it's filed, you can let other members know via any of the communication channels that you need an approval.
+Any existing member can give an approval in the issue, and any member with rights to add you to the project team can do so once the issue has received at least one(1) approval from an existing team member.
+
+If you have any questions, you can ask on the mailing list, in Slack, or by filing an issue in GitHub.


### PR DESCRIPTION
- We want to expand to have all workstream members in the GitHub
  project.
- But we're relatively small and very few of us have direct git
  or GitHub experience.
- In a January 2022 meeting of the workstream, outgoing WS chair
  Celeste Horgan asked if I would write up a lightweight, just-
  enough, minimal viable governance/team charter for giving out
  git repo access for reviews, pull requests, etc.
- This PR is for discussion purposes and likely will be modified
  before it's merged.

Signed-off-by: Karsten Wade <kwade@redhat.com>